### PR TITLE
Ensure globs in npm scripts are quoted

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,10 +13,10 @@
     "bundle": "webpack --config ./webpack.config.production.js",
     "build": "tsc --build",
     "clean": "tsc --build --clean",
-    "lint": "eslint ./src/**/*.ts --fix",
-    "lint:nofix": "eslint ./src/**/*.ts",
-    "format": "prettier ./src/**/*.ts --write",
-    "format:check": "prettier ./src/**/*.ts --check"
+    "lint": "eslint './src/**/*.ts' --fix",
+    "lint:nofix": "eslint './src/**/*.ts'",
+    "format": "prettier './src/**/*.ts' --write",
+    "format:check": "prettier './src/**/*.ts' --check"
   },
   "devDependencies": {
     "@types/bn.js": "^5.1.1",


### PR DESCRIPTION
Ensure globs in npm scripts are quoted

Because: https://medium.com/@jakubsynowiec/you-should-always-quote-your-globs-in-npm-scripts-621887a2a784