### PR TITLE
Move getTransaction for Solana to RPC provider

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kycdao/kycdao-sdk",
-  "version": "0.6.18",
+  "version": "0.6.19",
   "description": "kycDAO SDK for TypeScript and JavaScript",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/blockchains/solana/solana-provider-wrapper.ts
+++ b/src/blockchains/solana/solana-provider-wrapper.ts
@@ -8,9 +8,7 @@ import {
 import { clusterApiUrl, Connection, Transaction } from '@solana/web3.js';
 import bs58 from 'bs58';
 import { InternalError } from '../../errors';
-import {
-  SolanaBlockchainNetwork,
-} from '../../types';
+import { SolanaBlockchainNetwork } from '../../types';
 import { isLike } from '../../utils';
 
 const WalletAdapterNetworkMapping: Record<SolanaBlockchainNetwork, WalletAdapterNetwork> = {
@@ -96,5 +94,5 @@ export class SolanaProviderWrapper {
     }
 
     return await this._adapter.sendTransaction(mintTransaction, this._connection);
-  }    
+  }
 }

--- a/src/blockchains/solana/solana-provider-wrapper.ts
+++ b/src/blockchains/solana/solana-provider-wrapper.ts
@@ -10,8 +10,6 @@ import bs58 from 'bs58';
 import { InternalError } from '../../errors';
 import {
   SolanaBlockchainNetwork,
-  Transaction as SdkTransaction,
-  TransactionStatus as SdkTransactionStatus,
 } from '../../types';
 import { isLike } from '../../utils';
 
@@ -98,41 +96,5 @@ export class SolanaProviderWrapper {
     }
 
     return await this._adapter.sendTransaction(mintTransaction, this._connection);
-  }
-
-  public async getTransaction(txHash: string): Promise<SdkTransaction> {
-    try {
-      const receipt = await this._connection.getTransaction(txHash, {
-        commitment: 'finalized',
-        maxSupportedTransactionVersion: 0, // it has to be a number and the only number version is 0
-      });
-
-      if (receipt === null) {
-        throw new InternalError(`Transaction ${txHash} doesn't exist`);
-      } else {
-        const postTokenBalances = receipt.meta?.postTokenBalances;
-        const status: SdkTransactionStatus = receipt.meta?.err === null ? 'Success' : 'Unknown'; // TODO Should this be failure? I'm not sure how this works.
-        if (postTokenBalances && postTokenBalances.length === 1) {
-          const tokenAmount = postTokenBalances[0].uiTokenAmount;
-          if (tokenAmount.uiAmount === 1 && tokenAmount.decimals === 0) {
-            const tokenId = postTokenBalances[0].mint;
-            return {
-              status: status,
-              data: tokenId.toString(),
-            };
-          } else {
-            return {
-              status: status,
-            };
-          }
-        } else {
-          return {
-            status: status,
-          };
-        }
-      }
-    } catch (e) {
-      throw new InternalError(`Unexpected error while checking Solana transaction: ${e}`);
-    }
-  }
+  }    
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -421,17 +421,19 @@ export class KycDao extends ApiBase {
           };
         }
       }
-      case 'Solana':
+      case 'Solana': {
         if (!this.solana) {
           throw new ConfigurationError('Solana support is not enabled.');
         }
 
         const rpcUrl = this.getNetworkDetails(chainAndAddress.blockchainNetwork).rpc_urls[0];
 
-        // We actually don't use the contract address for the getTransaction call so 
+        // We actually don't use the contract address for the getTransaction call so
         // it's fine that we've hardcoded the VerificationType to KYC here.
         const contractAddress =
-          this.apiStatus?.smart_contracts_info?.[chainAndAddress.blockchainNetwork]?.[VerificationTypes.KYC]?.address;
+          this.apiStatus?.smart_contracts_info?.[chainAndAddress.blockchainNetwork]?.[
+            VerificationTypes.KYC
+          ]?.address;
         if (!contractAddress) {
           throw new InternalError('No contract address found for Solana.');
         }
@@ -439,6 +441,7 @@ export class KycDao extends ApiBase {
         const solanaProvider = new SolanaJsonRpcProvider(contractAddress, rpcUrl);
 
         return await solanaProvider.getTransaction(txHash);
+      }
       default:
         throw new UnreachableCaseError(chainAndAddress.blockchain);
     }


### PR DESCRIPTION
Basically, the ProviderWrapper doesn't have the RPC from backend but the JSONRPCProvider does, so we're moving the getTransaction call there instead